### PR TITLE
Silverstripe SS_Object introduced in 3.7.0

### DIFF
--- a/code/forms/ExternalDataFormScaffolder.php
+++ b/code/forms/ExternalDataFormScaffolder.php
@@ -6,7 +6,7 @@
  * @uses DBField::scaffoldFormField()
  * @uses ExternalDataObject::fieldLabels()
  */
-class ExternalDataFormScaffolder extends Object {
+class ExternalDataFormScaffolder extends SS_Object {
 	
 	/**
 	 * @var DataObject $obj The object defining the fields to be scaffolded

--- a/code/forms/ExternalDataGridFieldDetailForm.php
+++ b/code/forms/ExternalDataGridFieldDetailForm.php
@@ -15,12 +15,12 @@ class ExternalDataGridFieldDetailForm extends GridFieldDetailForm {
 		if($request->param('ID') && $request->param('ID') != 'new') {
 			$record = $gridField->getList()->byId($request->param("ID"));
 		} else {
-			$record = Object::create($gridField->getModelClass());	
+			$record = SS_Object::create($gridField->getModelClass());
 		}
 
 		$class = $this->getItemRequestClass();
 
-		$handler = Object::create($class, $gridField, $this, $record, $controller, $this->name);
+		$handler = SS_Object::create($class, $gridField, $this, $record, $controller, $this->name);
 		$handler->setTemplate($this->template);
 
 		return $handler->handleRequest($request, DataModel::inst());

--- a/code/model/ExternalDataObject.php
+++ b/code/model/ExternalDataObject.php
@@ -226,7 +226,7 @@ abstract class ExternalDataObject extends ArrayData implements ExternalDataInter
 			return new ExternalDataObjectPrimaryKey('ID', $this->ID); // ?Varchar
 		// General casting information for items in $db
 		} else if($helper = $this->db($fieldName)) {
-			$obj = Object::create_from_string($helper, $fieldName);
+			$obj = SS_Object::create_from_string($helper, $fieldName);
 			$obj->setValue($this->$fieldName, $this->record, false);
 			return $obj;
 		}
@@ -330,7 +330,7 @@ abstract class ExternalDataObject extends ArrayData implements ExternalDataInter
 		}
 		$castingHelper = $this->castingHelper($fieldName);
 		if($castingHelper) {
-			$fieldObj = Object::create_from_string($castingHelper, $fieldName);
+			$fieldObj = SS_Object::create_from_string($castingHelper, $fieldName);
 			$fieldObj->setValue($val);
 			$fieldObj->saveInto($this);
 		} else {
@@ -352,7 +352,7 @@ abstract class ExternalDataObject extends ArrayData implements ExternalDataInter
 		// Otherwise, we need to determine if this is a complex field
 		if(self::is_composite_field($this->class, $field)) {
 			$helper = $this->castingHelper($field);
-			$fieldObj = Object::create_from_string($helper, $field);
+			$fieldObj = SS_Object::create_from_string($helper, $field);
 
 			$compositeFields = $fieldObj->compositeDatabaseFields();
 			foreach ($compositeFields as $compositeName => $compositeType) {


### PR DESCRIPTION
SilverStripe 3.7 now supports PHP 7.2, which is exciting, but PHP 7.2 introduces an object keyword. To use it, you can replace any uses of Object with SS_Object in your own project code.